### PR TITLE
Add missing semicolon to docstore workflow example

### DIFF
--- a/root/050-dev/025-standard-plugin/document-store/050-workflow.txt
+++ b/root/050-dev/025-standard-plugin/document-store/050-workflow.txt
@@ -248,7 +248,7 @@ P.EgWorkflow.use("std:document_store", {
     priority: 100,
     path: "/do/example-plugin/application-form"
     formsForKey: function(key) {
-        return [application]
+        return [application];
     },
     blankDocumentForKey: function(key) {
         var applicant = key.entities.applicant;


### PR DESCRIPTION
Fixes a minor syntax error in example code